### PR TITLE
Dummy PR: Debugging nf-test ngscheckmate/ncm in Sarek

### DIFF
--- a/modules.json
+++ b/modules.json
@@ -36,6 +36,11 @@
                         "git_sha": "618364f55cb88f6c283f6c6c45c24d5f9f08f998",
                         "installed_by": ["modules"]
                     },
+                    "bedtools/makewindows": {
+                        "branch": "master",
+                        "git_sha": "3b248b84694d1939ac4bb33df84bf6233a34d668",
+                        "installed_by": ["modules"]
+                    },
                     "bwa/index": {
                         "branch": "master",
                         "git_sha": "086fa66260595e123b0ea47a6512539b72a9afa3",

--- a/modules/nf-core/bedtools/makewindows/environment.yml
+++ b/modules/nf-core/bedtools/makewindows/environment.yml
@@ -1,0 +1,7 @@
+name: bedtools_makewindows
+channels:
+  - conda-forge
+  - bioconda
+  - defaults
+dependencies:
+  - bioconda::bedtools=2.31.1

--- a/modules/nf-core/bedtools/makewindows/main.nf
+++ b/modules/nf-core/bedtools/makewindows/main.nf
@@ -1,0 +1,49 @@
+process BEDTOOLS_MAKEWINDOWS {
+    tag "$meta.id"
+    label 'process_single'
+
+    conda "${moduleDir}/environment.yml"
+    container "${ workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'https://depot.galaxyproject.org/singularity/bedtools:2.31.1--hf5e1c6e_0' :
+        'biocontainers/bedtools:2.31.1--hf5e1c6e_0' }"
+
+    input:
+    tuple val(meta), path(regions)
+
+    output:
+    tuple val(meta), path("*.bed"), emit: bed
+    path "versions.yml"           , emit: versions
+
+    when:
+    task.ext.when == null || task.ext.when
+
+    script:
+    def args = task.ext.args ?: ''
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    def arg_input = regions.extension in ["bed", "tab"] ? "-b ${regions}" : "-g ${regions}"
+    if ("${regions}" == "${prefix}.bed") error "Input and output names are the same, set prefix in module configuration to disambiguate!"
+    """
+    bedtools \\
+        makewindows \\
+        ${arg_input} \\
+        ${args} \\
+        > ${prefix}.bed
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        bedtools: \$(bedtools --version | sed -e "s/bedtools v//g")
+    END_VERSIONS
+    """
+
+    stub:
+    def prefix = task.ext.prefix ?: "${meta.id}"
+    if ("${regions}" == "${prefix}.bed") error "Input and output names are the same, set prefix in module configuration to disambiguate!"
+    """
+    touch ${prefix}.bed
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        bedtools: \$(bedtools --version | sed -e "s/bedtools v//g")
+    END_VERSIONS
+    """
+}

--- a/modules/nf-core/bedtools/makewindows/meta.yml
+++ b/modules/nf-core/bedtools/makewindows/meta.yml
@@ -1,0 +1,44 @@
+name: bedtools_makewindows
+description: Makes adjacent or sliding windows across a genome or BED file.
+keywords:
+  - bed
+  - windows
+  - fai
+  - chunking
+tools:
+  - bedtools:
+      description: A set of tools for genomic analysis tasks, specifically enabling genome arithmetic (merge, count, complement) on various file types.
+      homepage: https://bedtools.readthedocs.io
+      documentation: https://bedtools.readthedocs.io/en/latest/content/tools/makewindows.html
+      doi: "10.1093/bioinformatics/btq033"
+      licence: ["MIT"]
+input:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - regions:
+      type: file
+      description: BED file OR Genome details file (<chromName><TAB><chromSize>)
+      pattern: "*.{bed,tab,fai}"
+output:
+  - meta:
+      type: map
+      description: |
+        Groovy Map containing sample information
+        e.g. [ id:'test', single_end:false ]
+  - versions:
+      type: file
+      description: File containing software versions
+      pattern: "versions.yml"
+  - bed:
+      type: file
+      description: BED file containing the windows
+      pattern: "*.bed"
+authors:
+  - "@kevbrick"
+  - "@nvnieuwk"
+maintainers:
+  - "@kevbrick"
+  - "@nvnieuwk"

--- a/modules/nf-core/ngscheckmate/ncm/tests/main.nf.test
+++ b/modules/nf-core/ngscheckmate/ncm/tests/main.nf.test
@@ -19,7 +19,7 @@ nextflow_process {
             process {
                 """
                 input[0] = [ [ id:'test' ],
-                         file(params.test_data['sarscov2']['genome']['test_bed'], checkIfExists: true)
+                         file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/bed/test.bed', checkIfExists: true)
                          ]
                 """
             }
@@ -31,11 +31,11 @@ nextflow_process {
                 """
                 input[0] =  [
                             [ id:'test1' ], // meta map
-                            file(params.test_data['sarscov2']['illumina']['test_paired_end_sorted_bam'], checkIfExists: true),
-                            file(params.test_data['sarscov2']['genome']['test_bed'], checkIfExists: true)
+                            file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.sorted.bam', checkIfExists: true),
+                            file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/bed/test.bed', checkIfExists: true)
                         ]
                 input[1] = [ [ id:'sarscov2' ],
-                         file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+                         file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
                          ]
                 input[2] = false
                 """
@@ -48,11 +48,11 @@ nextflow_process {
                 """
                 input[0] =  [
                             [ id:'test2' ], // meta map
-                            file(params.test_data['sarscov2']['illumina']['test_paired_end_sorted_bam'], checkIfExists: true),
-                            file(params.test_data['sarscov2']['genome']['test_bed'], checkIfExists: true)
+                            file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.sorted.bam', checkIfExists: true),
+                            file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/bed/test.bed', checkIfExists: true)
                         ]
                 input[1] = [ [ id:'sarscov2' ],
-                         file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+                         file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
                          ]
                 input[2] = false
                 """
@@ -68,15 +68,15 @@ nextflow_process {
             process {
                 """
                 input[0] = [ [ id: 'combined_bams' ],
-                         [file(params.test_data['sarscov2']['illumina']['test_paired_end_sorted_bam']               , checkIfExists: true ),
-                          file(params.test_data['sarscov2']['illumina']['test_paired_end_sorted_bam_bai']           , checkIfExists: true ),
-                          file(params.test_data['sarscov2']['illumina']['test_paired_end_methylated_sorted_bam']    , checkIfExists: true ),
-                          file(params.test_data['sarscov2']['illumina']['test_paired_end_methylated_sorted_bam_bai'], checkIfExists: true )
+                         [file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.sorted.bam'               , checkIfExists: true ),
+                          file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.sorted.bam.bai'           , checkIfExists: true ),
+                          file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.methylated.sorted.bam'    , checkIfExists: true ),
+                          file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.methylated.sorted.bam.bai', checkIfExists: true )
                           ]
                      ]
                 input[1] = BEDTOOLS_MAKEWINDOWS.out.bed
                 input[2] = [ [ id:'sarscov2' ],
-                         file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+                         file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
                          ]
                 """
             }
@@ -104,7 +104,7 @@ nextflow_process {
                 input[0] = BCFTOOLS_MPILEUP1.out.vcf.combine(BCFTOOLS_MPILEUP2.out.vcf.map{it[1]}).map{meta, one, two -> [meta, [one, two]]}.map{meta, stuff -> [meta, stuff.flatten()]}
                 input[1] = BEDTOOLS_MAKEWINDOWS.out.bed
                 input[2] = [ [ id:'sarscov2' ],
-                         file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+                         file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
                          ]
                 """
             }
@@ -133,15 +133,15 @@ nextflow_process {
             process {
                 """
                 input[0] = [ [ id: 'combined_bams' ],
-                         [file(params.test_data['sarscov2']['illumina']['test_paired_end_sorted_bam']               , checkIfExists: true ),
-                          file(params.test_data['sarscov2']['illumina']['test_paired_end_sorted_bam_bai']           , checkIfExists: true ),
-                          file(params.test_data['sarscov2']['illumina']['test_paired_end_methylated_sorted_bam']    , checkIfExists: true ),
-                          file(params.test_data['sarscov2']['illumina']['test_paired_end_methylated_sorted_bam_bai'], checkIfExists: true )
+                         [file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.sorted.bam'               , checkIfExists: true ),
+                          file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.sorted.bam.bai'           , checkIfExists: true ),
+                          file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.methylated.sorted.bam'    , checkIfExists: true ),
+                          file(params.modules_testdata_base_path + 'genomics/sarscov2/illumina/bam/test.paired_end.methylated.sorted.bam.bai', checkIfExists: true )
                           ]
                      ]
                 input[1] = BEDTOOLS_MAKEWINDOWS.out.bed
                 input[2] = [ [ id:'sarscov2' ],
-                         file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+                         file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
                          ]
                 """
             }
@@ -166,7 +166,7 @@ nextflow_process {
                 input[0] = BCFTOOLS_MPILEUP1.out.vcf.combine(BCFTOOLS_MPILEUP2.out.vcf.map{it[1]})
                 input[1] = BEDTOOLS_MAKEWINDOWS.out.bed
                 input[2] = [ [ id:'sarscov2' ],
-                         file(params.test_data['sarscov2']['genome']['genome_fasta'], checkIfExists: true)
+                         file(params.modules_testdata_base_path + 'genomics/sarscov2/genome/genome.fasta', checkIfExists: true)
                          ]
                 """
             }

--- a/modules/nf-core/ngscheckmate/ncm/tests/main.nf.test.snap
+++ b/modules/nf-core/ngscheckmate/ncm/tests/main.nf.test.snap
@@ -163,87 +163,47 @@
         "content": [
             {
                 "0": [
-                    [
-                        {
-                            "id": "test1"
-                        },
-                        "test1_output_corr_matrix.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
+                    
                 ],
                 "1": [
-                    [
-                        {
-                            "id": "test1"
-                        },
-                        "test1_matched.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
+                    
                 ],
                 "2": [
-                    [
-                        {
-                            "id": "test1"
-                        },
-                        "test1_all.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
+                    
                 ],
                 "3": [
-                    [
-                        {
-                            "id": "test1"
-                        },
-                        "test1.pdf:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
+                    
                 ],
                 "4": [
                     
                 ],
                 "5": [
-                    "versions.yml:md5,7ac92d9cbf4fc44b3253832f3a8b2a80"
+                    
                 ],
                 "all": [
-                    [
-                        {
-                            "id": "test1"
-                        },
-                        "test1_all.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
+                    
                 ],
                 "corr_matrix": [
-                    [
-                        {
-                            "id": "test1"
-                        },
-                        "test1_output_corr_matrix.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
+                    
                 ],
                 "matched": [
-                    [
-                        {
-                            "id": "test1"
-                        },
-                        "test1_matched.txt:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
+                    
                 ],
                 "pdf": [
-                    [
-                        {
-                            "id": "test1"
-                        },
-                        "test1.pdf:md5,d41d8cd98f00b204e9800998ecf8427e"
-                    ]
+                    
                 ],
                 "vcf": [
                     
                 ],
                 "versions": [
-                    "versions.yml:md5,7ac92d9cbf4fc44b3253832f3a8b2a80"
+                    
                 ]
             }
         ],
         "meta": {
             "nf-test": "0.8.4",
-            "nextflow": "24.04.1"
+            "nextflow": "24.04.2"
         },
-        "timestamp": "2024-05-22T15:20:40.816531052"
+        "timestamp": "2024-06-06T07:28:37.380569721"
     }
 }


### PR DESCRIPTION
Dummy PR - don't merge!

I can't run the following nf-test in Sarek:
```
nf-test test --profile=docker --verbose --debug modules/nf-core/ngscheckmate/ncm --updateSnapshot
```
There are a couple of issues with the nf-test for `ngscheckmate/ncm`, in particular, it assumes that the module `bedtools/makewindows` is installed.

With the changes in this dummy PR, I got 3 out of 4 tests working.

What follows it the log from the failing test:
```
  Test [214966b7] 'sarscov2 - vcf'

    Profiles: [docker]
    Configs: [nextflow.config, conf/test.config, /home/ubuntu/dev/sarek_maxulysse/modules/nf-core/ngscheckmate/ncm/tests/./nextflow.config, /home/ubuntu/dev/sarek_maxulysse/modules/nf-core/ngscheckmate/ncm/tests/./vcf.config]
    Command: /home/ubuntu/mambaforge/envs/nf-core/bin/nextflow -log /home/ubuntu/dev/sarek_maxulysse/.nf-test/tests/214966b78ba50a966671851e09d892cd/meta/nextflow.log run /home/ubuntu/dev/sarek_maxulysse/.nf-test/tests/214966b78ba50a966671851e09d892cd/meta/mock.nf -c /home/ubuntu/dev/sarek_maxulysse/nextflow.config -c /home/ubuntu/dev/sarek_maxulysse/conf/test.config -c /home/ubuntu/dev/sarek_maxulysse/modules/nf-core/ngscheckmate/ncm/tests/./nextflow.config -c /home/ubuntu/dev/sarek_maxulysse/modules/nf-core/ngscheckmate/ncm/tests/./vcf.config -params-file /home/ubuntu/dev/sarek_maxulysse/.nf-test/tests/214966b78ba50a966671851e09d892cd/meta/params.json -ansi-log false -profile docker -with-trace /home/ubuntu/dev/sarek_maxulysse/.nf-test/tests/214966b78ba50a966671851e09d892cd/meta/trace.csv -w /home/ubuntu/dev/sarek_maxulysse/.nf-test/tests/214966b78ba50a966671851e09d892cd/work
    > N E X T F L O W  ~  version 24.04.2
    > Launching `/home/ubuntu/dev/sarek_maxulysse/.nf-test/tests/214966b78ba50a966671851e09d892cd/meta/mock.nf` [dreamy_minsky] DSL2 - revision: fc1da8e981
    > [35/3ce065] Submitted process > BEDTOOLS_MAKEWINDOWS (test)

    Stdout:
      N E X T F L O W  ~  version 24.04.2
      Launching `/home/ubuntu/dev/sarek_maxulysse/.nf-test/tests/214966b78ba50a966671851e09d892cd/meta/mock.nf` [dreamy_minsky] DSL2 - revision: fc1da8e981
      [35/3ce065] Submitted process > BEDTOOLS_MAKEWINDOWS (test)

    Stderr:

    Nextflow Output:
      N E X T F L O W  ~  version 24.04.2
      Enabled plugins: []
      Disabled plugins: []
      PF4J version 3.10.0 in 'deployment' mode
      No plugins
      revision: fc1da8e981
      Plugin 'nf-validation@1.1.3' resolved
      Start plugin 'nf-validation@1.1.3'
      Plugin 'nf-prov@1.2.2' resolved
      Start plugin 'nf-prov@1.2.2'
      Plugin 'nf-amazon@2.5.2' resolved
      Start plugin 'nf-amazon@2.5.2'
      [35/3ce065] Submitted process > BEDTOOLS_MAKEWINDOWS (test)
      Stop plugin 'nf-amazon@2.5.2'
      Stop plugin 'nf-prov@1.2.2'
      Stop plugin 'nf-validation@1.1.3'

        Output Channels:
    {
        "0": [

        ],
        "1": [

        ],
        "2": [

        ],
        "3": [

        ],
        "4": [

        ],
        "5": [

        ],
        "all": [

        ],
        "corr_matrix": [

        ],
        "matched": [

        ],
        "pdf": [

        ],
        "vcf": [

        ],
        "versions": [

        ]
    }
java.lang.NullPointerException: Cannot invoke method getAt() on null object
FAILED (11.025s)

  Assertion failed:

  1 of 2 assertions failed

Assertion failed:

1 of 2 assertions failed

	at com.askimed.nf.test.lang.extensions.GlobalMethods.assertAll(GlobalMethods.java:48)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:107)
	at groovy.lang.MetaMethod.doMethodInvoke(MetaMethod.java:323)
	at org.codehaus.groovy.runtime.callsite.StaticMetaMethodSite.invoke(StaticMetaMethodSite.java:44)
	at org.codehaus.groovy.runtime.callsite.StaticMetaMethodSite.callStatic(StaticMetaMethodSite.java:100)
	at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCallStatic(CallSiteArray.java:55)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callStatic(AbstractCallSite.java:217)
	at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callStatic(AbstractCallSite.java:240)
	at main_nf$_run_closure1$_closure4$_closure20.doCall(main.nf.test:120)
	at main_nf$_run_closure1$_closure4$_closure20.doCall(main.nf.test)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at org.codehaus.groovy.reflection.CachedMethod.invoke(CachedMethod.java:107)
	at groovy.lang.MetaMethod.doMethodInvoke(MetaMethod.java:323)
	at org.codehaus.groovy.runtime.metaclass.ClosureMetaClass.invokeMethod(ClosureMetaClass.java:274)
	at groovy.lang.MetaClassImpl.invokeMethod(MetaClassImpl.java:1030)
	at groovy.lang.Closure.call(Closure.java:427)
	at groovy.lang.Closure.call(Closure.java:406)
	at com.askimed.nf.test.lang.TestCode.execute(TestCode.java:16)
	at com.askimed.nf.test.lang.process.ProcessTest.execute(ProcessTest.java:169)
	at com.askimed.nf.test.core.TestExecutionEngine.execute(TestExecutionEngine.java:214)
	at com.askimed.nf.test.commands.RunTestsCommand.execute(RunTestsCommand.java:184)
	at com.askimed.nf.test.commands.AbstractCommand.call(AbstractCommand.java:43)
	at com.askimed.nf.test.commands.AbstractCommand.call(AbstractCommand.java:18)
	at picocli.CommandLine.executeUserObject(CommandLine.java:1953)
	at picocli.CommandLine.access$1300(CommandLine.java:145)
	at picocli.CommandLine$RunLast.executeUserObjectOfLastSubcommandWithSameParent(CommandLine.java:2352)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2346)
	at picocli.CommandLine$RunLast.handle(CommandLine.java:2311)
	at picocli.CommandLine$AbstractParseResultHandler.execute(CommandLine.java:2179)
	at picocli.CommandLine.execute(CommandLine.java:2078)
	at com.askimed.nf.test.App.run(App.java:44)
	at com.askimed.nf.test.App.main(App.java:51)
  Nextflow stdout:

  N E X T F L O W  ~  version 24.04.2
  Launching `/home/ubuntu/dev/sarek_maxulysse/.nf-test/tests/214966b78ba50a966671851e09d892cd/meta/mock.nf` [dreamy_minsky] DSL2 - revision: fc1da8e981
  [35/3ce065] Submitted process > BEDTOOLS_MAKEWINDOWS (test)
  Nextflow stderr:
```